### PR TITLE
feat: dynamic form generation using randomized schema

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,25 @@
+import json
+import random
+from flask import Flask, jsonify, render_template
+
+app = Flask(__name__)
+
+with open('data/fields.json') as f:
+    ALL_FIELDS = json.load(f)
+
+
+@app.route('/schema')
+def schema():
+    fields = ALL_FIELDS[:]
+    random.shuffle(fields)
+    count = random.randint(1, len(fields))
+    return jsonify(fields[:count])
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/data/fields.json
+++ b/data/fields.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "first_name",
+    "label": "First Name",
+    "type": "text",
+    "validation": {"required": true, "minLength": 2}
+  },
+  {
+    "name": "email",
+    "label": "Email",
+    "type": "email",
+    "validation": {"required": true}
+  },
+  {
+    "name": "age",
+    "label": "Age",
+    "type": "number",
+    "validation": {"min": 0, "max": 120}
+  },
+  {
+    "name": "subscribe",
+    "label": "Subscribe to newsletter",
+    "type": "checkbox",
+    "validation": {"required": false}
+  }
+]

--- a/static/js/form.js
+++ b/static/js/form.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('/schema')
+    .then((res) => res.json())
+    .then((fields) => renderForm(fields));
+});
+
+function renderForm(fields) {
+  const form = document.getElementById('dynamic-form');
+  form.innerHTML = '';
+  fields.forEach((field) => {
+    const wrapper = document.createElement('div');
+
+    const label = document.createElement('label');
+    label.textContent = field.label;
+    label.setAttribute('for', field.name);
+
+    let input;
+    if (field.type === 'checkbox') {
+      input = document.createElement('input');
+      input.type = 'checkbox';
+    } else {
+      input = document.createElement('input');
+      input.type = field.type || 'text';
+    }
+    input.name = field.name;
+    input.id = field.name;
+
+    if (field.validation) {
+      if (field.validation.required) input.required = true;
+      if (field.validation.minLength) input.minLength = field.validation.minLength;
+      if (field.validation.min !== undefined) input.min = field.validation.min;
+      if (field.validation.max !== undefined) input.max = field.validation.max;
+    }
+
+    wrapper.appendChild(label);
+    wrapper.appendChild(input);
+    form.appendChild(wrapper);
+  });
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Dynamic Form</title>
+  <script src="{{ url_for('static', filename='js/form.js') }}" defer></script>
+</head>
+<body>
+  <h1>Dynamic Form</h1>
+  <form id="dynamic-form"></form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add JSON field schema and Flask backend returning randomized subsets
- render dynamic form on the frontend based on fetched schema

## Testing
- `python -m json.tool data/fields.json`
- `python -m py_compile app.py`
- `node --check static/js/form.js`


------
https://chatgpt.com/codex/tasks/task_e_68b496ee676c832f886aad9af05579f3