### PR TITLE
Add dynamic form validation with phone and SSN checks

### DIFF
--- a/static/js/form.js
+++ b/static/js/form.js
@@ -35,5 +35,13 @@ function renderForm(fields) {
     wrapper.appendChild(label);
     wrapper.appendChild(input);
     form.appendChild(wrapper);
+
+    if (typeof attachValidation === 'function') {
+      attachValidation(input, field.validation || {});
+    }
   });
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.textContent = 'Submit';
+  form.appendChild(submit);
 }

--- a/static/js/validation.js
+++ b/static/js/validation.js
@@ -1,0 +1,76 @@
+const fieldErrors = {};
+
+function isValidPhone(value) {
+  const digits = value.replace(/\D/g, '');
+  return /^\d{10}$/.test(digits);
+}
+
+function isValidSSN(value) {
+  return /^\d{3}-\d{2}-\d{4}$/.test(value);
+}
+
+function withinLength(value, max = 15) {
+  return value.length <= max;
+}
+
+function validateField(input, rules = {}) {
+  const value = input.value.trim();
+  const name = input.name;
+  const errors = [];
+
+  if (rules.required && !value) {
+    errors.push(`${name} is required`);
+  }
+
+  if (value && !withinLength(value)) {
+    errors.push(`${name} must be at most 15 characters`);
+  }
+
+  if (name.toLowerCase().includes('phone') && value && !isValidPhone(value)) {
+    errors.push('Phone number must be 10 digits');
+  }
+
+  if (name.toLowerCase().includes('ssn') && value && !isValidSSN(value)) {
+    errors.push('SSN must match ###-##-####');
+  }
+
+  if (rules.minLength && value.length < rules.minLength) {
+    errors.push(`${name} must be at least ${rules.minLength} characters`);
+  }
+
+  if (rules.min !== undefined && value !== '' && Number(value) < rules.min) {
+    errors.push(`${name} must be at least ${rules.min}`);
+  }
+
+  if (rules.max !== undefined && value !== '' && Number(value) > rules.max) {
+    errors.push(`${name} must be at most ${rules.max}`);
+  }
+
+  if (errors.length) {
+    fieldErrors[name] = errors;
+  } else {
+    delete fieldErrors[name];
+  }
+  renderErrors();
+}
+
+function renderErrors() {
+  const container = document.getElementById('error-messages');
+  if (!container) return;
+  container.innerHTML = '';
+  Object.values(fieldErrors).forEach((errs) => {
+    errs.forEach((err) => {
+      const p = document.createElement('p');
+      p.textContent = err;
+      container.appendChild(p);
+    });
+  });
+}
+
+function attachValidation(input, rules) {
+  input.addEventListener('input', () => validateField(input, rules));
+  input.addEventListener('blur', () => validateField(input, rules));
+}
+
+// expose to global scope
+window.attachValidation = attachValidation;

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,10 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <title>Dynamic Form</title>
+  <script src="{{ url_for('static', filename='js/validation.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/form.js') }}" defer></script>
 </head>
 <body>
   <h1>Dynamic Form</h1>
   <form id="dynamic-form"></form>
+  <div id="error-messages" style="color: red;"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add validation utilities for phone numbers, SSNs, and length limits
- hook validation into dynamically generated form inputs and show errors
- load validation script and error container in the form template
- add a submit button to the dynamically generated form

## Testing
- `.venv/bin/python -m pytest`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b499020c1c832f9711ecb67f732735