### PR TITLE
Ensure PDF directory uses project path

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ app = Flask(__name__)
 with open("data/fields.json") as f:
     ALL_FIELDS = json.load(f)
 
-PDF_DIR = "pdf"
+PDF_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "pdf")
 os.makedirs(PDF_DIR, exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- use absolute path for PDF_DIR so pdf files are generated in the project's pdf folder regardless of working directory

## Testing
- `python -m py_compile app.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4a864d314832fabcb7d16b3e9205c