### PR TITLE
Handle dynamic form submission

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ app = Flask(__name__)
 with open("data/fields.json") as f:
     ALL_FIELDS = json.load(f)
 
-PDF_DIR = "pdf"
+PDF_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "pdf")
 os.makedirs(PDF_DIR, exist_ok=True)
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,5 +10,6 @@
   <h1>Dynamic Form</h1>
   <form id="dynamic-form"></form>
   <div id="error-messages" style="color: red;"></div>
+  <div id="result"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- send dynamic form data to the Flask backend via a new `handleSubmit` handler
- display PDF download link or server-side validation errors
- add placeholder in the template for result messages

## Testing
- `python -m py_compile app.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4a864d314832fabcb7d16b3e9205c