### PR TITLE
Expand dynamic form fields with server-side validation, styling, and multi-step flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,10 +27,9 @@ os.makedirs(PDF_DIR, exist_ok=True)
 
 @app.route('/schema')
 def schema():
-    fields = ALL_FIELDS[:]
+    fields = list(ALL_FIELDS)
     random.shuffle(fields)
-    count = random.randint(1, len(fields))
-    return jsonify(fields[:count])
+    return jsonify(fields)
 
 
 @app.route('/')
@@ -49,6 +48,22 @@ def is_valid_phone(value):
 
 def is_valid_ssn(value):
     return bool(re.fullmatch(r"\d{3}-\d{2}-\d{4}", value))
+
+
+def is_valid_date(value):
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_zip(value):
+    return bool(re.fullmatch(r"\d{5}", value))
+
+
+def is_valid_state(value):
+    return bool(re.fullmatch(r"[A-Za-z]{2}", value))
 
 
 def validate_data(data):
@@ -80,6 +95,15 @@ def validate_data(data):
 
             if "ssn" in lname and not is_valid_ssn(value):
                 field_errors.append("SSN must match ###-##-####")
+
+            if ("dob" in lname or "date" in lname) and not is_valid_date(value):
+                field_errors.append("Date must be YYYY-MM-DD")
+
+            if "zip" in lname and not is_valid_zip(value):
+                field_errors.append("ZIP Code must be 5 digits")
+
+            if "state" in lname and not is_valid_state(value):
+                field_errors.append("State must be two letters")
 
             min_len = rules.get("minLength")
             if min_len and len(value) < min_len:
@@ -116,7 +140,10 @@ def generate_pdf(data):
             app.logger.error("PDF generation failed: %s", e)
             return {"error": f"PDF generation failed: {e}"}
     try:
-        pdfkit.from_string(html, path)
+        if config:
+            pdfkit.from_string(html, path, configuration=config)
+        else:
+            pdfkit.from_string(html, path)
     except OSError as e:
         app.logger.error("PDF generation failed: %s", e)
         return {"error": f"PDF generation failed: {e}"}

--- a/data/fields.json
+++ b/data/fields.json
@@ -6,6 +6,18 @@
     "validation": {"required": true, "minLength": 2}
   },
   {
+    "name": "last_name",
+    "label": "Last Name",
+    "type": "text",
+    "validation": {"required": true, "minLength": 2}
+  },
+  {
+    "name": "middle_name",
+    "label": "Middle Name",
+    "type": "text",
+    "validation": {"required": false}
+  },
+  {
     "name": "email",
     "label": "Email",
     "type": "email",
@@ -22,5 +34,83 @@
     "label": "Subscribe to newsletter",
     "type": "checkbox",
     "validation": {"required": false}
+  },
+  {
+    "name": "ssn",
+    "label": "SSN",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "date_of_birth",
+    "label": "Date of Birth",
+    "type": "date",
+    "validation": {"required": true}
+  },
+  {
+    "name": "address",
+    "label": "Address",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "city",
+    "label": "City",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "state",
+    "label": "State",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "zip_code",
+    "label": "ZIP Code",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "phone_number",
+    "label": "Phone Number",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "attorney_name",
+    "label": "Attorney Name",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "case_number",
+    "label": "Case Number",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "employer_name",
+    "label": "Employer Name",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "gender",
+    "label": "Gender",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "marital_status",
+    "label": "Marital Status",
+    "type": "text",
+    "validation": {"required": true}
+  },
+  {
+    "name": "country",
+    "label": "Country",
+    "type": "text",
+    "validation": {"required": true}
   }
 ]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -16,11 +16,20 @@ h1 {
 }
 
 form {
-  width: 320px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem 2rem;
+  max-width: 640px;
+  margin: 0 auto;
 }
 
-form div {
-  margin-bottom: 1rem;
+.nice-form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.nice-form-group label {
+  margin-bottom: 0.25rem;
 }
 
 form input {
@@ -32,15 +41,37 @@ form input {
   box-sizing: border-box;
 }
 
-form button {
+.button {
   padding: 0.5rem 1rem;
-  background-color: #007bff;
   color: #fff;
   border: none;
   border-radius: 4px;
   cursor: pointer;
 }
 
-form button:hover {
+form .button {
+  grid-column: span 2;
+  background-color: #007bff;
+}
+
+form .button:hover {
   background-color: #0056b3;
+}
+
+#new-form.button {
+  background-color: #28a745;
+  display: block;
+  margin: 1rem auto 0;
+}
+
+#new-form.button:hover {
+  background-color: #218838;
+}
+
+.form-page {
+  display: contents;
+}
+
+.hidden {
+  display: none;
 }

--- a/static/js/form.js
+++ b/static/js/form.js
@@ -1,6 +1,10 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('dynamic-form');
   form.addEventListener('submit', handleSubmit);
+  const newFormBtn = document.getElementById('new-form');
+  if (newFormBtn) {
+    newFormBtn.addEventListener('click', () => window.location.reload());
+  }
   fetch('/schema')
     .then((res) => res.json())
     .then((fields) => renderForm(fields));
@@ -50,7 +54,13 @@ function handleSubmit(event) {
 function renderForm(fields) {
   const form = document.getElementById('dynamic-form');
   form.innerHTML = '';
-  fields.forEach((field) => {
+  const midpoint = Math.ceil(fields.length / 2);
+  const page1 = document.createElement('div');
+  page1.classList.add('form-page');
+  const page2 = document.createElement('div');
+  page2.classList.add('form-page', 'hidden');
+
+  fields.forEach((field, index) => {
     const wrapper = document.createElement('div');
     wrapper.classList.add('nice-form-group');
 
@@ -82,14 +92,30 @@ function renderForm(fields) {
       if (field.validation.max !== undefined) input.max = field.validation.max;
     }
 
-    form.appendChild(wrapper);
+    const targetPage = index < midpoint ? page1 : page2;
+    targetPage.appendChild(wrapper);
 
     if (typeof attachValidation === 'function') {
       attachValidation(input, field.validation || {});
     }
   });
+
+  const next = document.createElement('button');
+  next.type = 'button';
+  next.textContent = 'Next';
+  next.classList.add('button');
+  next.addEventListener('click', () => {
+    page1.classList.add('hidden');
+    page2.classList.remove('hidden');
+  });
+  page1.appendChild(next);
+
   const submit = document.createElement('button');
   submit.type = 'submit';
   submit.textContent = 'Submit';
-  form.appendChild(submit);
+  submit.classList.add('button');
+  page2.appendChild(submit);
+
+  form.appendChild(page1);
+  form.appendChild(page2);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,20 +3,18 @@
 <head>
   <meta charset="UTF-8">
   <title>Dynamic Form</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/nice-forms.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
   <script src="{{ url_for('static', filename='js/validation.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/form.js') }}" defer></script>
 </head>
 <body>
-  <h1>Dynamic Form</h1>
-  <form id="dynamic-form"></form>
-  <div id="error-messages" style="color: red;"></div>
-  <div id="result"></div>
-
   <div class="demo-page">
     <main class="demo-page-content">
       <section>
         <h1>Dynamic Form</h1>
         <form id="dynamic-form"></form>
+        <button id="new-form" class="button" type="button">New Form</button>
         <div id="error-messages" style="color: red;"></div>
         <div id="result"></div>
       </section>

--- a/tests/test_schema_order.py
+++ b/tests/test_schema_order.py
@@ -1,0 +1,22 @@
+import json
+import random
+
+import app
+
+
+def test_schema_shuffles_order():
+    with open('data/fields.json') as f:
+        all_fields = json.load(f)
+
+    random.seed(0)
+    expected = list(all_fields)
+    random.shuffle(expected)
+    expected_names = [f['name'] for f in expected]
+
+    client = app.app.test_client()
+    random.seed(0)
+    res = client.get('/schema')
+    assert res.status_code == 200
+    data = res.get_json()
+    names = [f['name'] for f in data]
+    assert names == expected_names

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -9,3 +9,23 @@ def test_validate_only_submitted_fields():
 def test_validate_required_field_present_but_empty():
     errors = app.validate_data({"email": ""})
     assert "email" in errors
+
+
+def test_validate_ssn_format():
+    errors = app.validate_data({"ssn": "123456789"})
+    assert "ssn" in errors
+
+
+def test_validate_date_format():
+    errors = app.validate_data({"date_of_birth": "01/01/1990"})
+    assert "date_of_birth" in errors
+
+
+def test_validate_zip_format():
+    errors = app.validate_data({"zip_code": "1234"})
+    assert "zip_code" in errors
+
+
+def test_validate_state_format():
+    errors = app.validate_data({"state": "California"})
+    assert "state" in errors


### PR DESCRIPTION
## Summary
- add 15 additional form fields including SSN, date of birth, address, and case details
- implement server-side validation for dates, ZIP codes, and states and return full schema
- style form with centered two-column layout and padded labels
- add a **New Form** button that reloads the page with fields in a randomized order
- style the New Form button to match submit styling with a distinct color
- split dynamic form into two pages with a Next button and a Submit button on the second page

## Testing
- `.venv/bin/python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4bb1c0bec832f95e0c009f4337be7